### PR TITLE
Remove ES6 dependency.

### DIFF
--- a/paper-accordion-element.html
+++ b/paper-accordion-element.html
@@ -258,19 +258,19 @@ paper-ripple {
             _GetCurrentItemHeight:function(){
                 return this.$.accordion_content_container.style['height'];
             },
-            _EnableTransitionDuration(shouldBeActivated){
+            _EnableTransitionDuration:function(shouldBeActivated){
                 this.$.accordion_content_container.style.transitionDuration = (shouldBeActivated ? '':'0s');
             },
-            _SetItemHeight(size){
+            _SetItemHeight:function(size){
                 this.$.accordion_content_container.style['height'] = size;
             },
-            _SetDisplay(displayValue){
+            _SetDisplay:function(displayValue){
                 this.$.accordion_content_container.style['display']=displayValue;
             },
-            _SetOffsetHeight(){
+            _SetOffsetHeight:function(){
                 this.$.accordion_content_container.offsetHeight = this.$.accordion_content_container.offsetHeight;
             },
-            _ChangeIcon(){
+            _ChangeIcon:function(){
                 if(!this.defaultIcon || !this.openIcon)return;
                 this.$.accordion_icon.icon = (this.isCollapsed) ? this.openIcon : this.defaultIcon;                 
             }	


### PR DESCRIPTION
Hi ichigo77.

I used jshint on your element and found that it had ES6 dependencies due to short function notation. In the same file both long and short notation is used so I changed to use long notation on all functions. This enables the usage of the component on IE11 which don't handle ES6 yet without a polyfill.

Keep up the good work.

Best regards
Daniel
